### PR TITLE
Date column now accepts DateTime instance

### DIFF
--- a/src/Columns/Date.php
+++ b/src/Columns/Date.php
@@ -70,6 +70,8 @@ class Date extends Filter {
 		if (is_numeric($data[$this->option[self::ID]])) {
 			$date = new \DateTime();
 			$date->setTimestamp($data[$this->option[self::ID]]);
+		} elseif ($data[$this->option[self::ID]] instanceof \DateTime) {
+			$date = $data[$this->option[self::ID]];
 		} else {
 			$date = new \DateTime($data[$this->option[self::ID]]);
 		}


### PR DESCRIPTION
If you tried to use instance of DateTime for Date column type, you would get error:

> DateTime::__construct() expects parameter 1 to be string, object given

This fixes this error.