### PR TITLE
fixed naming mismatch in BasicGrid

### DIFF
--- a/src/Grid/BasicGrid.php
+++ b/src/Grid/BasicGrid.php
@@ -421,7 +421,7 @@ class BasicGrid extends BaseGrid {
 		$body->addRow($row);
 	}
 
-	protected function addOpenedSubItemRow(Render\Body &$body, $rowData, $name, $keyItem, Item $item) {
+	protected function addOpenedSubItemRow(Render\Body &$body, $rowData, $name, $key, Item $item) {
 		$item->check($rowData);
 		if($item->isDisabled()) {
 			return;


### PR DESCRIPTION
V BasicGrid.php je proměnná $key, která není definována. Asi je to typo, protože v metodě parametr $keyItem není vůbec použit, tak jsem ho přejmenoval na $key.